### PR TITLE
Allow slow_lisp branch to be built by kaem

### DIFF
--- a/kaem.run
+++ b/kaem.run
@@ -16,30 +16,25 @@
 ## along with Gnu Mes.  If not, see <http://www.gnu.org/licenses/>.
 
 M2-Planet --debug --architecture amd64 \
-	-f mes.h -f mes_constants.h \
-	-f ../M2-Planet/test/common_amd64/functions/exit.c \
-	-f ../M2-Planet/test/common_amd64/functions/malloc.c \
-	-f functions/AMD64/fdputc.c \
-	-f ../M2-Planet/functions/calloc.c \
-	-f functions/file_print.c \
-	-f functions/numerate.c \
-	-f functions/in_set.c \
-	-f functions/match.c \
-	-f mes_builtins.c \
-	-f mes.c \
-	-f mes_eval.c \
-	-f mes_gc.c \
-	-f mes_hash.c \
-	-f mes_init.c \
-	-f mes_lib.c \
-	-f mes_math.c \
-	-f mes_module.c \
-	-f mes_posix.c \
-	-f mes_printer.c \
-	-f mes_reader.c \
-	-f mes_strings.c \
-	-f mes_struct.c \
-	-f mes_vector.c -o bin/mes.M1
+    -f mes.h \
+    -f ../M2-Planet/test/common_amd64/functions/file.c \
+    -f ../M2-Planet/test/common_amd64/functions/exit.c \
+    -f ../M2-Planet/test/common_amd64/functions/malloc.c \
+    -f ../M2-Planet/functions/calloc.c \
+    -f mes.c \
+    -f mes_cell.c \
+    -f mes_builtins.c \
+    -f mes_eval.c \
+    -f mes_print.c \
+    -f mes_read.c \
+    -f mes_tokenize.c \
+    -f mes_vector.c \
+    -f mes_list.c \
+    -f mes_string.c \
+    -f functions/numerate_number.c \
+    -f functions/match.c \
+    -f functions/file_print.c \
+    -f functions/envp.c -o bin/mes.M1
 
 blood-elf --64 -f bin/mes.M1 -o bin/mes-footer.M1
 

--- a/mes_cell.c
+++ b/mes_cell.c
@@ -186,7 +186,7 @@ void unmark_cells(struct cell* list, struct cell* stop, int count)
 void garbage_collect()
 {
 	mark_all_cells();
-	// TODO unmark stack
+	/* TODO unmark stack */
 	unmark_cells(all_symbols, all_symbols, 0);
 	unmark_cells(top_env, top_env, 0);
 	reclaim_marked();


### PR DESCRIPTION
I tried to build the slow_lisp branch with kaem... It failed; seems like it hadn't been changed from the merge. Here is a fix.

Also fixes a comment to use /* */ instead of // otherwise I was having trouble compiling.