### PR TITLE
Mescc compilation fixes

### DIFF
--- a/functions/file_print.c
+++ b/functions/file_print.c
@@ -35,7 +35,7 @@ char char_lookup(int c)
 	else if(c == '\n') return 'n';
 	else if(c == '\f') return 'f';
 	else if(c == '\r') return 'r';
-	else if(c == '\e') return 'e';
+	else if(c == '\033') return 'e';
 	else if(c == '\\') return '\\';
 	else if(c == '"') return '"';
 	return c;
@@ -106,7 +106,7 @@ void raw_print(char* s, FILE* f)
 	while(0 != s[0])
 	{
 		c = s[0];
-		if(in_set(c, "\a\b\t\b\v\f\n\r\e\"\\"))
+		if(in_set(c, "\a\b\t\b\v\f\n\r\033\"\\"))
 		{
 			fputc('\\', f);
 			c = char_lookup(c);

--- a/gcc_req.h
+++ b/gcc_req.h
@@ -22,5 +22,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#if __MESC__
+typedef void FUNCTION;
+#else
 typedef struct cell* (FUNCTION)(struct cell *);
+#endif
+
 typedef long SCM;

--- a/mes.c
+++ b/mes.c
@@ -56,7 +56,7 @@ int REPL()
 	int read;
 	/* Read S-Expression block */
 	reset_block(message);
-	read = Readline(__stdin->file, message);
+	read = Readline(__c_stdin->file, message);
 	if(0 == read) return TRUE;
 
 	/* Process S-expression */
@@ -68,17 +68,17 @@ int REPL()
 	eval();
 
 	/* Print */
-	if(match("/dev/stdin", __stdin->string) && (NULL != R1) && (cell_unspecified != R1))
+	if(match("/dev/stdin", __c_stdin->string) && (NULL != R1) && (cell_unspecified != R1))
 	{
-		file_print("$R0 = ", __stdout->file);
-		writeobj(__stdout, R1, TRUE);
-		fputc('\n', __stdout->file);
+		file_print("$R0 = ", __c_stdout->file);
+		writeobj(__c_stdout, R1, TRUE);
+		fputc('\n', __c_stdout->file);
 	}
 
 	/* Display user friendly prompt */
-	if(match("/dev/stdin", __stdin->string))
+	if(match("/dev/stdin", __c_stdin->string))
 	{
-		file_print("REPL: ", __stdout->file);
+		file_print("REPL: ", __c_stdout->file);
 	}
 	return FALSE;
 }
@@ -92,14 +92,14 @@ struct cell* load_file(char* s)
 	/* Punt on bad inputs */
 	if(NULL == f) return cell_unspecified;
 
-	push_cell(__stdin);
-	__stdin = make_file(f, s);
+	push_cell(__c_stdin);
+	__c_stdin = make_file(f, s);
 	while(!Reached_EOF)
 	{
 		garbage_collect();
 		Reached_EOF = REPL();
 	}
-	__stdin = pop_cell();
+	__c_stdin = pop_cell();
 	return cell_t;
 }
 
@@ -137,9 +137,9 @@ int main(int argc, char **argv, char** envp)
 	g_stack = calloc(MAX_STACK, sizeof(struct cell*));
 
 	/* Initialization: stdin, stdout and stderr */
-	__stdin = make_file(stdin, "/dev/stdin");
-	__stdout = make_file(stdout, "/dev/stdout");
-	__stderr = make_file(stderr, "/dev/stderr");
+	__c_stdin = make_file(stdin, "/dev/stdin");
+	__c_stdout = make_file(stdout, "/dev/stdout");
+	__c_stderr = make_file(stderr, "/dev/stderr");
 
 	char* testing = env_lookup("MES_CORE", envp);
 	if(NULL != testing)
@@ -180,9 +180,9 @@ int main(int argc, char **argv, char** envp)
 			}
 		}
 
-		file_print("REPL: ", __stdout->file);
+		file_print("REPL: ", __c_stdout->file);
 		load_file("/dev/stdin");
-		file_print("\nexiting, have a nice day!\n", __stdout->file);
+		file_print("\nexiting, have a nice day!\n", __c_stdout->file);
 		exit(EXIT_SUCCESS);
 	}
 	else

--- a/mes.h
+++ b/mes.h
@@ -116,9 +116,9 @@ struct cell* unquote_splicing;
 char** __argv;
 char** __envp;
 int __argc;
-struct cell* __stderr;
-struct cell* __stdin;
-struct cell* __stdout;
+struct cell* __c_stderr;
+struct cell* __c_stdin;
+struct cell* __c_stdout;
 
 /* Garbage Collection */
 char* memory_block;

--- a/mes_builtins.c
+++ b/mes_builtins.c
@@ -578,7 +578,7 @@ struct cell* builtin_primitive_load(struct cell* args)
 
 struct cell* builtin_read_byte(struct cell* args)
 {
-	if(nil == args) return make_char(fgetc(__stdin->file));
+	if(nil == args) return make_char(fgetc(__c_stdin->file));
 	else if(FILE_PORT == args->car->type)
 	{
 		int c = fgetc(args->car->file);

--- a/mes_cell.c
+++ b/mes_cell.c
@@ -663,7 +663,7 @@ struct cell* make_proc(struct cell* a, struct cell* b, struct cell* env)
  *  | PRIMOP | POINTER | NULL | NULL |  *
  *   --------------------------------   *
  ****************************************/
-struct cell* make_prim(FUNCTION fun)
+struct cell* make_prim(FUNCTION* fun)
 {
 	struct cell* c = pop_cons();
 	c->type = PRIMOP;
@@ -755,4 +755,16 @@ struct cell* make_record(struct cell* type, struct cell* vector)
 	struct cell* c = pop_cons();
 	c->type = EOF_object;
 	return c;
+}
+
+struct cell* cell_invoke_function(struct cell* cell, struct cell* vals)
+{
+// /* hide from M2-Planet
+#if __MESC__
+	struct cell* (*fp)(struct cell*) = cell->function;
+#else
+// */
+	FUNCTION* fp = cell->function;
+#endif
+	return fp(vals);
 }

--- a/mes_cell.c
+++ b/mes_cell.c
@@ -399,9 +399,9 @@ void garbage_collect()
 	unmark_cells(R2);
 	unmark_cells(R3);
 	unmark_cells(R4);
-	__stdin->type = __stdin->type & ~MARKED;
-	__stdout->type = __stdout->type & ~MARKED;
-	__stderr->type = __stderr->type & ~MARKED;
+	__c_stdin->type = __c_stdin->type & ~MARKED;
+	__c_stdout->type = __c_stdout->type & ~MARKED;
+	__c_stderr->type = __c_stderr->type & ~MARKED;
 	unmark_stack();
 
 	/* Step two: reclaim marked cells */

--- a/mes_eval.c
+++ b/mes_eval.c
@@ -26,6 +26,7 @@ struct cell* make_proc(struct cell* a, struct cell* b, struct cell* env);
 struct cell* reverse_list(struct cell* head);
 struct cell* string_eq(struct cell* a, struct cell* b);
 struct cell* vector_equal(struct cell* a, struct cell* b);
+struct cell* cell_invoke_function(struct cell* cell, struct cell* vals);
 
 
 /* Support functions */
@@ -165,8 +166,7 @@ void apply(struct cell* proc, struct cell* vals)
 	if(proc->type == PRIMOP)
 	{
 		/* Deal with the simple case of if we have a primitive */
-		fp = proc->function;
-		R1 = fp(vals);
+		R1 = cell_invoke_function(proc, vals);
 		return;
 	}
 	else if(proc->type == LAMBDA)

--- a/mes_macro.c
+++ b/mes_macro.c
@@ -28,6 +28,7 @@ struct cell* make_proc(struct cell* a, struct cell* b, struct cell* env);
 struct cell* pop_cell();
 struct cell* reverse_list(struct cell* head);
 void push_cell(struct cell* a);
+struct cell* cell_invoke_function(struct cell* cell, struct cell* vals);
 
 struct cell* macro_extend_env(struct cell* sym, struct cell* val, struct cell* env)
 {
@@ -344,8 +345,7 @@ struct cell* macro_apply(struct cell* proc, struct cell* vals)
 	struct cell* temp;
 	if(proc->type == PRIMOP)
 	{
-		FUNCTION* fp = proc->function;
-		temp = fp(vals);
+		temp = cell_invoke_function(proc, vals);
 	}
 	else if(proc->type == LAMBDA)
 	{

--- a/mes_posix.c
+++ b/mes_posix.c
@@ -72,7 +72,7 @@ struct cell* builtin_display(struct cell* args)
 	require(nil != args, "display requires arguments\n");
 	if(nil == args->cdr)
 	{
-		prim_display(args, __stdout);
+		prim_display(args, __c_stdout);
 		return cell_unspecified;
 	}
 
@@ -87,7 +87,7 @@ struct cell* builtin_display_error(struct cell* args)
 	require(nil != args, "display-error requires arguments\n");
 	if(nil == args->cdr)
 	{
-		prim_display(args, __stderr);
+		prim_display(args, __c_stderr);
 		return cell_unspecified;
 	}
 
@@ -101,7 +101,7 @@ struct cell* builtin_write(struct cell* args)
 	require(nil != args, "write requires arguments\n");
 	if(nil == args->cdr)
 	{
-		prim_write(args, __stdout);
+		prim_write(args, __c_stdout);
 		return cell_unspecified;
 	}
 	require(FILE_PORT == args->cdr->car->type, "You passed something that isn't a file pointer to write in position 2\n");
@@ -115,7 +115,7 @@ struct cell* builtin_write_error(struct cell* args)
 	require(nil != args, "write-error requires arguments\n");
 	if(nil == args->cdr)
 	{
-		return prim_write(args, __stderr);
+		return prim_write(args, __c_stderr);
 	}
 
 	require(FILE_PORT == args->cdr->car->type, "You passed something that isn't a file pointer to write in position 2\n");
@@ -183,8 +183,8 @@ struct cell* builtin_set_current_output_port(struct cell* args)
 	require(FILE_PORT == args->car->type, "set-current-output-port expects a port\n");
 	require(nil == args->cdr, "set-current-output-port expects only a single argument\n");
 
-	__stdout->file = args->car->file;
-	__stdout->string = args->car->string;
+	__c_stdout->file = args->car->file;
+	__c_stdout->string = args->car->string;
 	return cell_unspecified;
 }
 
@@ -194,8 +194,8 @@ struct cell* builtin_set_current_input_port(struct cell* args)
 	require(FILE_PORT == args->car->type, "set-current-input-port expects a port\n");
 	require(nil == args->cdr, "set-current-input-port expects only a single argument\n");
 
-	__stdin->file = args->car->file;
-	__stdin->string = args->car->string;
+	__c_stdin->file = args->car->file;
+	__c_stdin->string = args->car->string;
 	return cell_unspecified;
 }
 
@@ -205,27 +205,27 @@ struct cell* builtin_set_current_error_port(struct cell* args)
 	require(FILE_PORT == args->car->type, "set-current-error-port expects a port\n");
 	require(nil == args->cdr, "set-current-error-port expects only a single argument\n");
 
-	__stderr->file = args->car->file;
-	__stderr->string = args->car->string;
+	__c_stderr->file = args->car->file;
+	__c_stderr->string = args->car->string;
 	return cell_unspecified;
 }
 
 struct cell* builtin_current_input_port(struct cell* args)
 {
 	require(nil == args, "current-input-port does not accept arguments\n");
-	return __stdin;
+	return __c_stdin;
 }
 
 struct cell* builtin_current_output_port(struct cell* args)
 {
 	require(nil == args, "current-output-port does not accept arguments\n");
-	return __stdout;
+	return __c_stdout;
 }
 
 struct cell* builtin_current_error_port(struct cell* args)
 {
 	require(nil == args, "current-error-port does not accept arguments\n");
-	return __stderr;
+	return __c_stderr;
 }
 
 struct cell* builtin_ttyname(struct cell* args)


### PR DESCRIPTION
Make Mes-M2 compilable with Mescc.

Only rudimentary tested (started and exited the REPL), as Mes-m2 mescc does not work yet.