### PR TITLE
Various code changes

### DIFF
--- a/mes/module/mes/let.mes
+++ b/mes/module/mes/let.mes
@@ -41,7 +41,7 @@
      (set! ,name (lambda ,(map1 car bindings) ,@rest))
      (,name ,@(map1 cadr bindings))))
 
-(define-macro (let bindings-or-name . rest)
+(define-macro (mes-let bindings-or-name . rest)
   (if (symbol? bindings-or-name)
       `(xnamed-let ,bindings-or-name ,(car rest) ,(cdr rest))
       `(xsimple-let ,bindings-or-name ,rest)))

--- a/mes/module/mes/let.mes
+++ b/mes/module/mes/let.mes
@@ -49,9 +49,9 @@
 (define (expand-let* bindings body)
   (if (null? bindings)
       `((lambda () ,@body))
-      `((lambda (,(caar bindings))
-          ,(expand-let* (cdr bindings) body))
-        ,@(cdar bindings))))
+      (cons (list 'lambda (list (caar bindings))
+          (expand-let* (cdr bindings) body))
+        (cdar bindings))))
 
 (define-macro (let* bindings . body)
   (expand-let* bindings body))

--- a/mes/module/mes/quasiquote.mes
+++ b/mes/module/mes/quasiquote.mes
@@ -55,5 +55,5 @@
                (quasiquote-expand (car x))
                (quasiquote-expand (cdr x))))))
 
-(define-macro (quasiquote x)
+(define-macro (mes-quasiquote x)
   (quasiquote-expand x))

--- a/mes/module/mes/scm.mes
+++ b/mes/module/mes/scm.mes
@@ -63,7 +63,7 @@
       (if (null? xr) (begin (f (car l)) (for-each f (cdr l)))
           (if (null? (cdr xr)) (begin (f (car l) (caar xr)) (for-each f (cdr l) (cdar xr)))))))
 
-(define core:error error)
+(define (core:error . args) (display args (currrent-error-port)))
 
 (define (error who . rest)
   (display "error:" (current-error-port))
@@ -309,7 +309,7 @@
 
 
 ;;; Math
-(define quotient /)
+;;(define quotient /)
 
 (define (<= . rest)
   (or (apply < rest)

--- a/mes_init.c
+++ b/mes_init.c
@@ -274,7 +274,7 @@ void init_sl3()
 
 	/* Dealing with Lists */
 	spinup(make_sym("list"), make_prim(builtin_list));
-	spinup(make_sym("append"), make_prim(builtin_append));
+	spinup(make_sym("append2"), make_prim(builtin_append));
 	spinup(make_sym("length"), make_prim(builtin_list_length));
 	spinup(make_sym("list->string"), make_prim(builtin_list_to_string));
 	spinup(make_sym("list->vector"), make_prim(builtin_list_to_vector));

--- a/mes_list.c
+++ b/mes_list.c
@@ -129,7 +129,7 @@ struct cell* builtin_append(struct cell* args)
 	if(nil == args) return nil;
 	require(((nil == args->car) || (CONS == args->car->type)), "append requires a list\n");
 	if(nil == args->cdr) return args->car;
-	require(((nil == args->car) || (CONS == args->car->type)), "append requires a list argument\n");
+	require(((nil == args->cdr->car) || (CONS == args->cdr->car->type)), "append requires a list argument\n");
 	return append(args->car, args->cdr->car);
 }
 

--- a/mes_macro.c
+++ b/mes_macro.c
@@ -65,6 +65,8 @@ struct cell* expand_quasiquote()
 	push_cell(R4);
 
 	/* (quasiquote (...)) */
+	require (NULL != R0, "quasiquote R0 is NULL\n");
+	require(NULL != R0->cdr, "quasiquote R0->cdr is NULL\n");
 	R2 = R0->cdr->car;
 	R3 = NULL;
 	while(nil != R2)
@@ -199,6 +201,7 @@ struct cell* expand_let()
 	/* Clean up locals after let completes */
 	push_cell(g_env);
 
+	require(NULL != R0->cdr, "expand_let R0->cdr is NULL\n");
 	/* Protect the s-expression from garbage collection */
 	push_cell(R0->cdr->cdr);
 
@@ -206,6 +209,7 @@ struct cell* expand_let()
 	for(R0 = R0->cdr->car; R0 != nil; R0 = R0->cdr)
 	{
 		push_cell(R0);
+		require (NULL != R0->car, "expand_let R0->car is NULL in loop\n");
 		R0 = R0->car->cdr->car;
 		macro_eval(R0, R1);
 		R0 = pop_cell();

--- a/mes_string.c
+++ b/mes_string.c
@@ -240,7 +240,9 @@ struct cell* builtin_string_to_symbol(struct cell* args)
 	require(STRING == args->car->type, "string->symbol requires a string\n");
 	struct cell* r = findsym(args->car->string);
 	if(nil != r) return r->car;
-	return make_sym(args->car->string);
+	struct cell* newsym =  make_sym(args->car->string);
+	all_symbols = make_cons(newsym, all_symbols);
+	return newsym;
 }
 
 struct cell* builtin_symbol_to_string(struct cell* args)
@@ -248,7 +250,7 @@ struct cell* builtin_symbol_to_string(struct cell* args)
 	require(nil != args, "symbol->string requires an argument\n");
 	require(nil == args->cdr, "symbol->string only supports a single argument\n");
 	require(SYM == args->car->type, "symbol->string requires a symbol\n");
-	return make_string(args->car->string, args->car->length);
+	return make_string(args->car->string, string_size(args->car->string));
 }
 
 struct cell* builtin_number_to_string(struct cell* args)

--- a/mes_tokenize.c
+++ b/mes_tokenize.c
@@ -96,7 +96,7 @@ struct cell* tokenize(struct cell* head, char* fullstring, unsigned size)
 		}
 		else
 		{
-			if(in_set(c, " \t\n\r"))
+			if(in_set(c, " \t\n\r\f"))
 			{
 				string_index = string_index + 1;
 				out_index = out_index + 1;

--- a/module/mes/boot-0.scm
+++ b/module/mes/boot-0.scm
@@ -127,6 +127,17 @@
 (define (assv i l) (cond ((null? l) #f) ((eqv? i (caar l)) (car l)) (else (assv i (cdr l)))))
 (define (assoc i l) (cond ((null? l) #f) ((equal? i (caar l)) (car l)) (else (assoc i (cdr l)))))
 
+;; environment
+(define *fake-env* '())
+(define getenv0 getenv)
+(define (getenv var)
+  (let ((fv (assoc var *fake-env*)))
+    (if fv (cdr fv) (getenv0 var))))
+(define (setenv var val)
+  (set! *fake-env* (cons (cons var val) *fake-env*))
+  (if #f #f))
+
+
 ;; Provide guile primitives
 (define (keyword-like-symbol->keyword sym)
   (if (symbol? sym) (string->keyword (list->string (cons* #\# #\: (cdr (string->list (symbol->string sym))))))


### PR DESCRIPTION
This started with fixing symbol->string and string->symbol, but got a few more fixes that came up once module loading worked.

At the moment when trying to load mes/module/mes/boot.scm, it does not segfault, but probably is stuck again in a macro expansion bug.

My suggested readme change comes in a separate pull request, as it may bring up more controversy.

Feel free to cherry-pick what you like and drop what you don't like.